### PR TITLE
Support emacs binary outside /usr/bin

### DIFF
--- a/bin/e2ansi-cat
+++ b/bin/e2ansi-cat
@@ -1,4 +1,4 @@
-#!/usr/bin/emacs --script
+#!/usr/bin/env -S emacs --script
 ;;; e2ansi-cat --- Output syntax highlighted versions using ANSI sequences
 
 ;; -*- emacs-lisp -*-

--- a/bin/e2ansi-info
+++ b/bin/e2ansi-info
@@ -1,4 +1,4 @@
-#!/usr/bin/emacs --script
+#!/usr/bin/env -S emacs --script
 ;;; e2ansi-info --- Print various things to help fine-tuning your terminal
 
 ;; -*- emacs-lisp -*-


### PR DESCRIPTION
Use /usr/bin/env  to support emacs elsewhere in PATH.