### PR TITLE
`*e2ansi-bash*` tweaks

### DIFF
--- a/e2ansi.el
+++ b/e2ansi.el
@@ -532,6 +532,8 @@ Replace the path to the home directory with `~'."
   (interactive)
   (let ((buf (get-buffer-create "*e2ansi-bash*")))
     (with-current-buffer buf
+      (sh-mode)
+      (sh-set-shell "bash" t nil)
       (erase-buffer)
       (let ((emacs-cmd (or (car-safe command-line-args)
                            "emacs")))

--- a/e2ansi.el
+++ b/e2ansi.el
@@ -582,6 +582,7 @@ executed directly, for example in MS-Windows.")
         (insert "\n")
         (insert "export \"LESS=-R\"\n")
         (insert "export \"MORE=-R\"\n"))
+      (view-mode)
       (goto-char (point-min)))
     (display-buffer buf)))
 

--- a/e2ansi.el
+++ b/e2ansi.el
@@ -581,7 +581,8 @@ executed directly, for example in MS-Windows.")
         (insert "# -R -- Emit raw bytes (needed to display ANSI sequences).\n")
         (insert "\n")
         (insert "export \"LESS=-R\"\n")
-        (insert "export \"MORE=-R\"\n")))
+        (insert "export \"MORE=-R\"\n"))
+      (goto-char (point-min)))
     (display-buffer buf)))
 
 


### PR DESCRIPTION
- Enable syntax highlighting in `*e2ansi-bash*` buffer.
- Move the cursor to the start of the `*e2ansi-bash*` buffer, with the intention of drawing the eye of the user to the place where they should start reading.
- Enable `view-mode` in the `*e2ansi-bash*` buffer, since the user is not intended to edit it.